### PR TITLE
add support for %NULLVALUE% handling to `Clean::EmptyFieldGroups`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kiba-extend (1.9.0)
+    kiba-extend (1.10.0)
       activesupport
       kiba (>= 4.0.0)
       kiba-common (>= 1.5.0)

--- a/lib/kiba/extend/transforms/clean.rb
+++ b/lib/kiba/extend/transforms/clean.rb
@@ -6,8 +6,9 @@ module Kiba
 
         module Helpers
           ::Clean::Helpers = Kiba::Extend::Transforms::Clean::Helpers
-          def delim_only?(val, delim)
+          def delim_only?(val, delim, usenull = false)
             chk = val.gsub(delim, '').strip
+            chk = chk.gsub('%NULLVALUE%', '').strip if usenull
             chk.empty? ? true : false
           end
         end
@@ -53,13 +54,14 @@ module Kiba
         
         class DelimiterOnlyFields
           include Clean::Helpers
-          def initialize(delim:)
+          def initialize(delim:, use_nullvalue: false)
             @delim = delim
+            @use_nullvalue = use_nullvalue
           end
 
           def process(row)
             row.each do |hdr, val|
-              row[hdr] = nil if val.is_a?(String) && delim_only?(val, @delim)
+              row[hdr] = nil if val.is_a?(String) && delim_only?(val, @delim, @use_nullvalue)
             end
             row
           end

--- a/lib/kiba/extend/version.rb
+++ b/lib/kiba/extend/version.rb
@@ -1,5 +1,5 @@
 module Kiba
   module Extend
-    VERSION = "1.9.1"
+    VERSION = "1.10.0"
   end
 end

--- a/spec/kiba/extend/transforms/clean_spec.rb
+++ b/spec/kiba/extend/transforms/clean_spec.rb
@@ -69,24 +69,42 @@ RSpec.describe Kiba::Extend::Transforms::Clean do
   end
 
   describe 'DelimiterOnlyFields' do
-    test_csv = 'tmp/test.csv'
-    rows = [
-        ['id', 'in_set'],
-        ['1', 'a; b'],
-        ['2', ';'],
-        ['3', nil]
-      ]
+    let(:test_csv) { 'tmp/test.csv' }
+    let(:rows) { [
+      ['id', 'in_set'],
+      ['1', 'a; b'],
+      ['2', ';'],
+      ['3', nil],
+      ['4', '%NULLVALUE%;%NULLVALUE%;%NULLVALUE%']
+    ] }
+    let(:result) { execute_job(filename: test_csv, xform: Clean::DelimiterOnlyFields, xformopt: options) }
+
+    before { generate_csv(test_csv, rows) }
+    after { File.delete(test_csv) if File.exist?(test_csv) }
     
-      before { generate_csv(test_csv, rows) }
-      let(:result) { execute_job(filename: test_csv, xform: Clean::DelimiterOnlyFields, xformopt: {delim: ';'}) }
+    context 'when use_nullvalue = false (the default)' do
+      let(:options) { {delim: ';'} }
       it 'changes delimiter only fields to nil' do
         expect(result[1][:in_set]).to be_nil
       end
       it 'leaves other fields unchanged' do
         expect(result[0][:in_set]).to eq('a; b')
         expect(result[2][:in_set]).to be_nil
+        expect(result[3][:in_set]).to eq('%NULLVALUE%;%NULLVALUE%;%NULLVALUE%')
       end
-      after { File.delete(test_csv) if File.exist?(test_csv) }
+    end
+
+    context 'when use_nullvalue = true' do
+      let(:options) { {delim: ';', use_nullvalue: true} }
+      it 'changes delimiter only fields to nil' do
+        expect(result[1][:in_set]).to be_nil
+        expect(result[3][:in_set]).to be_nil
+      end
+      it 'leaves other fields unchanged' do
+        expect(result[0][:in_set]).to eq('a; b')
+        expect(result[2][:in_set]).to be_nil
+      end
+    end
   end
 
   describe 'DowncaseFieldValues' do


### PR DESCRIPTION
Adds a transform initialization parameter: `use_nullvalue`

Defaults to `false` if not set explicitly, so this change does not affect the behavior of code written before this parameter was available. 

If `use_nullvalue` is set to `true`, the transform will:

- enforce explicit blankness of values by inserting %NULLVALUE% before any sep at beginning of string, after any sep at end of string, and between any two sep with nothing in between
- Consider %NULLVALUE% to be a blank value, so if all values in a field are %NULLVALUE%, the field will be nil-ed out. 