### PR TITLE
Add `Merge::CompareFieldsFlag` transform

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kiba-extend (1.12.0)
+    kiba-extend (1.12.1)
       activesupport
       kiba (>= 4.0.0)
       kiba-common (>= 1.5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kiba-extend (1.12.1)
+    kiba-extend (1.13.0)
       activesupport
       kiba (>= 4.0.0)
       kiba-common (>= 1.5.0)

--- a/lib/kiba/extend/transforms/merge.rb
+++ b/lib/kiba/extend/transforms/merge.rb
@@ -5,11 +5,12 @@ module Kiba
         ::Merge = Kiba::Extend::Transforms::Merge
 
         class CompareFieldsFlag
-          def initialize(fields:, target:, downcase: true, strip: true)
+          def initialize(fields:, target:, downcase: true, strip: true, ignore_blank: false)
             @fields = fields
             @target = target
             @strip = strip
             @downcase = downcase
+            @ignore_blank = ignore_blank
           end
 
           def process(row)
@@ -22,7 +23,8 @@ module Kiba
               value.strip! if @strip
               values << value
             end
-            row[@target] = 'same' if values.uniq.length == 1
+            values.reject!{ |val| val.blank? } if @ignore_blank
+            row[@target] = 'same' if values.uniq.length == 1 || values.empty?
             row
           end
         end

--- a/lib/kiba/extend/transforms/merge.rb
+++ b/lib/kiba/extend/transforms/merge.rb
@@ -4,6 +4,29 @@ module Kiba
       module Merge
         ::Merge = Kiba::Extend::Transforms::Merge
 
+        class CompareFieldsFlag
+          def initialize(fields:, target:, downcase: true, strip: true)
+            @fields = fields
+            @target = target
+            @strip = strip
+            @downcase = downcase
+          end
+
+          def process(row)
+            row[@target] = 'diff'
+            values = []
+            @fields.each do |field|
+              value = row.fetch(field, '').dup
+              value = '' if value.nil?
+              value.downcase! if @downcase
+              value.strip! if @strip
+              values << value
+            end
+            row[@target] = 'same' if values.uniq.length == 1
+            row
+          end
+        end
+
         class ConstantValue
           def initialize(target:, value:)
             @target = target

--- a/lib/kiba/extend/version.rb
+++ b/lib/kiba/extend/version.rb
@@ -1,5 +1,5 @@
 module Kiba
   module Extend
-    VERSION = "1.12.1"
+    VERSION = "1.13.0"
   end
 end

--- a/spec/kiba/extend/transforms/merge_spec.rb
+++ b/spec/kiba/extend/transforms/merge_spec.rb
@@ -16,10 +16,11 @@ RSpec.describe Kiba::Extend::Transforms::Merge do
       [2, nil, 2],
       ['three', 'Three', 'three'],
       ['three', ' three', 'three'],
-      [4, 4, 3]
+      [4, 4, 3],
+      ['', nil, '']
     ] }
 
-    context 'with defaults (downcase and strip)' do
+    context 'with defaults (downcase and strip = true, ignore_blank = false)' do
       it 'merges "same" or "diff" into target field after comparing values in row fields' do
         expected = [
           {id: '1', pid: '1', zid: '1', comp: 'same'},
@@ -27,6 +28,7 @@ RSpec.describe Kiba::Extend::Transforms::Merge do
           {id: 'three', pid: 'Three', zid: 'three', comp: 'same'},
           {id: 'three', pid: ' three', zid: 'three', comp: 'same'},
           {id: '4', pid: '4', zid: '3', comp: 'diff'},
+          {id: '', pid: nil, zid: '', comp: 'same'}
         ]
         result = execute_job(filename: test_csv,
                              xform: Merge::CompareFieldsFlag,
@@ -43,6 +45,7 @@ RSpec.describe Kiba::Extend::Transforms::Merge do
           {id: 'three', pid: 'Three', zid: 'three', comp: 'diff'},
           {id: 'three', pid: ' three', zid: 'three', comp: 'same'},
           {id: '4', pid: '4', zid: '3', comp: 'diff'},
+          {id: '', pid: nil, zid: '', comp: 'same'}
         ]
         result = execute_job(filename: test_csv,
                              xform: Merge::CompareFieldsFlag,
@@ -51,7 +54,7 @@ RSpec.describe Kiba::Extend::Transforms::Merge do
       end
     end
 
-    context 'with strip false)' do
+    context 'with strip false' do
       it 'merges "same" or "diff" into target field after comparing values in row fields' do
         expected = [
           {id: '1', pid: '1', zid: '1', comp: 'same'},
@@ -59,10 +62,28 @@ RSpec.describe Kiba::Extend::Transforms::Merge do
           {id: 'three', pid: 'Three', zid: 'three', comp: 'same'},
           {id: 'three', pid: ' three', zid: 'three', comp: 'diff'},
           {id: '4', pid: '4', zid: '3', comp: 'diff'},
+          {id: '', pid: nil, zid: '', comp: 'same'}
         ]
         result = execute_job(filename: test_csv,
                              xform: Merge::CompareFieldsFlag,
                              xformopt: {fields: %i[id pid zid], target: :comp, strip: false})
+        expect(result).to eq(expected)
+      end
+    end
+
+    context 'with ignore_blank = true' do
+      it 'merges "same" or "diff" into target field after comparing values in row fields' do
+        expected = [
+          {id: '1', pid: '1', zid: '1', comp: 'same'},
+          {id: '2', pid: nil, zid: '2', comp: 'same'},
+          {id: 'three', pid: 'Three', zid: 'three', comp: 'same'},
+          {id: 'three', pid: ' three', zid: 'three', comp: 'same'},
+          {id: '4', pid: '4', zid: '3', comp: 'diff'},
+          {id: '', pid: nil, zid: '', comp: 'same'}
+        ]
+        result = execute_job(filename: test_csv,
+                             xform: Merge::CompareFieldsFlag,
+                             xformopt: {fields: %i[id pid zid], target: :comp, ignore_blank: true})
         expect(result).to eq(expected)
       end
     end

--- a/spec/kiba/extend/transforms/merge_spec.rb
+++ b/spec/kiba/extend/transforms/merge_spec.rb
@@ -8,6 +8,66 @@ RSpec.describe Kiba::Extend::Transforms::Merge do
   after do
     File.delete(test_csv) if File.exist?(test_csv)
   end
+
+  describe 'CompareFieldsFlag' do
+    let(:rows) { [
+      ['id', 'pid', 'zid'],
+      [1, 1, 1],
+      [2, nil, 2],
+      ['three', 'Three', 'three'],
+      ['three', ' three', 'three'],
+      [4, 4, 3]
+    ] }
+
+    context 'with defaults (downcase and strip)' do
+      it 'merges "same" or "diff" into target field after comparing values in row fields' do
+        expected = [
+          {id: '1', pid: '1', zid: '1', comp: 'same'},
+          {id: '2', pid: nil, zid: '2', comp: 'diff'},
+          {id: 'three', pid: 'Three', zid: 'three', comp: 'same'},
+          {id: 'three', pid: ' three', zid: 'three', comp: 'same'},
+          {id: '4', pid: '4', zid: '3', comp: 'diff'},
+        ]
+        result = execute_job(filename: test_csv,
+                             xform: Merge::CompareFieldsFlag,
+                             xformopt: {fields: %i[id pid zid], target: :comp})
+        expect(result).to eq(expected)
+      end
+    end
+
+    context 'with downcase false' do
+      it 'merges "same" or "diff" into target field after comparing values in row fields' do
+        expected = [
+          {id: '1', pid: '1', zid: '1', comp: 'same'},
+          {id: '2', pid: nil, zid: '2', comp: 'diff'},
+          {id: 'three', pid: 'Three', zid: 'three', comp: 'diff'},
+          {id: 'three', pid: ' three', zid: 'three', comp: 'same'},
+          {id: '4', pid: '4', zid: '3', comp: 'diff'},
+        ]
+        result = execute_job(filename: test_csv,
+                             xform: Merge::CompareFieldsFlag,
+                             xformopt: {fields: %i[id pid zid], target: :comp, downcase: false})
+        expect(result).to eq(expected)
+      end
+    end
+
+    context 'with strip false)' do
+      it 'merges "same" or "diff" into target field after comparing values in row fields' do
+        expected = [
+          {id: '1', pid: '1', zid: '1', comp: 'same'},
+          {id: '2', pid: nil, zid: '2', comp: 'diff'},
+          {id: 'three', pid: 'Three', zid: 'three', comp: 'same'},
+          {id: 'three', pid: ' three', zid: 'three', comp: 'diff'},
+          {id: '4', pid: '4', zid: '3', comp: 'diff'},
+        ]
+        result = execute_job(filename: test_csv,
+                             xform: Merge::CompareFieldsFlag,
+                             xformopt: {fields: %i[id pid zid], target: :comp, strip: false})
+        expect(result).to eq(expected)
+      end
+    end
+  end
+
   describe 'ConstantValue' do
     let(:rows) { [
       ['id', 'name', 'sex', 'source'],


### PR DESCRIPTION
Enters "same" into `target` if the value in all `fields` specified is the same. Otherwise, enters "diff" into `target`. 

`downcase` true converts all values to lowercase before comparing. `strip` true removes leading/trailing spaces. Neither option changes the values in `fields`

`ignore_blank` true would result in "same" if 2 field values were the same but 1 was empty. `ignore_blank` false would report "diff" in this situation.