### PR TITLE
Fix bug where CSV write fails if a non-existent initial_header is specified

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kiba-extend (2.5.0)
+    kiba-extend (2.5.1)
       activesupport (~> 6.1.4)
       csv (~> 3.0)
       dry-configurable (~> 0.11)
@@ -108,4 +108,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   2.1.4
+   2.2.22

--- a/lib/kiba/extend/version.rb
+++ b/lib/kiba/extend/version.rb
@@ -2,6 +2,6 @@
 
 module Kiba
   module Extend
-    VERSION = '2.5.0'
+    VERSION = '2.5.1'
   end
 end

--- a/spec/kiba/extend/destinations/csv_spec.rb
+++ b/spec/kiba/extend/destinations/csv_spec.rb
@@ -2,20 +2,19 @@
 
 require 'spec_helper'
 
-TEST_FILENAME = 'output.csv'
+RSpec.describe Kiba::Extend::Destinations::CSV do
+  TEST_FILENAME = 'output.csv'
+  def run_job(input)
+    job = Kiba.parse do
+      source Kiba::Common::Sources::Enumerable, input
+      destination Kiba::Extend::Destinations::CSV, filename: TEST_FILENAME, initial_headers: %i[y z]
+    end
 
-def run_job(input)
-  job = Kiba.parse do
-    source Kiba::Common::Sources::Enumerable, input
-    destination Kiba::Extend::Destinations::CSV, filename: TEST_FILENAME, initial_headers: %i[y z]
+    Kiba.run(job)
+
+    IO.read(TEST_FILENAME)
   end
 
-  Kiba.run(job)
-
-  IO.read(TEST_FILENAME)
-end
-
-RSpec.describe Kiba::Extend::Destinations::CSV do
   after(:each){ File.delete(TEST_FILENAME) if File.exist?(TEST_FILENAME) }
 
   context 'when intial headers present' do

--- a/spec/kiba/extend/destinations/csv_spec.rb
+++ b/spec/kiba/extend/destinations/csv_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+TEST_FILENAME = 'output.csv'
+
+def run_job(input)
+  job = Kiba.parse do
+    source Kiba::Common::Sources::Enumerable, input
+    destination Kiba::Extend::Destinations::CSV, filename: TEST_FILENAME, initial_headers: %i[y z]
+  end
+
+  Kiba.run(job)
+
+  IO.read(TEST_FILENAME)
+end
+
+RSpec.describe Kiba::Extend::Destinations::CSV do
+  after(:each){ File.delete(TEST_FILENAME) if File.exist?(TEST_FILENAME) }
+
+  context 'when intial headers present' do
+    let(:input) do
+      [
+        {a: 'and', y: 'yak', z: 'zebra'},
+        {a: 'apple', y: 'yarrow', z: 'zizia'}
+      ]
+    end
+    let(:expected) do
+      "y,z,a\nyak,zebra,and\nyarrow,zizia,apple\n"
+    end
+    it 'produces CSV as expected' do
+      expect(run_job(input)).to eq(expected)
+    end
+  end
+
+  context 'when intial headers specified but not present' do
+    let(:input) do
+      [
+        {a: 'and', z: 'zebra'},
+        {a: 'apple', z: 'zizia'}
+      ]
+    end
+    let(:expected) do
+      "z,a\nzebra,and\nzizia,apple\n"
+    end
+    it 'produces CSV as expected' do
+      expect(run_job(input)).to eq(expected)
+    end
+    it 'writes warning to STDOUT' do
+      msg = 'Output data does not contain specified initial header: y'
+      expect { run_job(input) }.to output(/#{msg}/).to_stdout
+    end
+  end
+end
+

--- a/spec/kiba/extend/destinations/json_array_spec.rb
+++ b/spec/kiba/extend/destinations/json_array_spec.rb
@@ -2,20 +2,20 @@
 
 require 'spec_helper'
 
-TEST_FILENAME = 'output.json'
+RSpec.describe Kiba::Extend::Destinations::JsonArray do
+  TEST_FILENAME = 'output.json'
 
-def run_job(input)
-  job = Kiba.parse do
-    source Kiba::Common::Sources::Enumerable, input
-    destination Kiba::Extend::Destinations::JsonArray, filename: TEST_FILENAME
+  def run_job(input)
+    job = Kiba.parse do
+      source Kiba::Common::Sources::Enumerable, input
+      destination Kiba::Extend::Destinations::JsonArray, filename: TEST_FILENAME
+    end
+
+    Kiba.run(job)
+
+    IO.read(TEST_FILENAME)
   end
 
-  Kiba.run(job)
-
-  IO.read(TEST_FILENAME)
-end
-
-RSpec.describe Kiba::Extend::Destinations::JsonArray do
   after(:each){ File.delete(TEST_FILENAME) if File.exist?(TEST_FILENAME) }
 
   context 'when simplest data ever' do


### PR DESCRIPTION
It is common in the development of a project to want to see a column
near the front of a CSV, but to later remove that column.

Previously, if you didn't remove that column from the
`initial_headers` specification, you'd get an ugly CSV write error
that would lead you down the wrong debugging path.

Now, you get a warning that should encourage you to update your output
file specifications, but the CSV will be written ignoring the missing column.

Closes #32 