### PR TITLE
add multival processing to `Cspace::NormalizeForID` transform

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,37 @@
+:toc:
+:toc-placement!:
+:toclevels: 4
+
+ifdef::env-github[]
+:tip-caption: :bulb:
+:note-caption: :information_source:
+:important-caption: :heavy_exclamation_mark:
+:caution-caption: :fire:
+:warning-caption: :warning:
+endif::[]
+
+= Changelog
+All notable changes to this project from 2021-10-04 onward will be documented in this file.
+
+Changes made prior to 2021-03-09 may ever be added retrospectively, but consult https://github.com/lyrasis/kiba-extend/releases/[Github Releases for the project] in the indefinite meantime.
+
+The format is based on https://keepachangelog.com/en/1.0.0/[Keep a Changelog],
+and this project adheres to https://semver.org/spec/v2.0.0.html[Semantic Versioning].
+
+toc::[]
+
+== Unreleased
+These changes are merged into the `main` branch but have not yet been tagged as a new version/release.
+
+==== Added
+- `multival` parameter added to `Cspace::NormalizeForID` transform (in https://github.com/lyrasis/kiba-extend/pull/49[PR#49])
+
+== Releases
+=== version - date
+
+https://github.com/lyrasis/kiba-extend/compare/v2.5.0...v2.5.1[Compare]
+
+==== Added
+==== Changed
+==== Deleted
+

--- a/lib/kiba/extend/transforms/cspace.rb
+++ b/lib/kiba/extend/transforms/cspace.rb
@@ -49,24 +49,35 @@ module Kiba
         end
 
         class NormalizeForID
-          def initialize(source:, target:)
+          def initialize(source:, target:, multival: false, delim: nil)
             @source = source
             @target = target
+            @multival = multival
+            @delim = delim
           end
 
           # @private
           def process(row)
+            row[@target] = nil
             val = row.fetch(@source, nil)
-            if val.blank?
-              row[@target] = nil
-            else
-              val = val.unicode_normalized?(:nfkc) ? val : val.unicode_normalize(:nfkc)
-              BRUTEFORCE.each { |k, v| val = val.gsub(k, v) }
-              norm = ActiveSupport::Inflector.transliterate(val)
-              norm = norm.gsub(/\W/, '')
-              row[@target] = norm.downcase
-            end
+            return row if val.blank?
+
+            row[@target] = values(val).map{ |val| normalize(val) }.join(@delim)
             row
+          end
+
+          private
+
+          def normalize(val)
+            val = val.unicode_normalized?(:nfkc) ? val : val.unicode_normalize(:nfkc)
+            BRUTEFORCE.each { |k, v| val = val.gsub(k, v) }
+            ActiveSupport::Inflector.transliterate(val).gsub(/\W/, '').downcase
+          end
+          
+          def values(val)
+            return [val] unless @multival
+
+            val.split(@delim)
           end
         end
       end


### PR DESCRIPTION
For fields that may contain multiple authority/vocabulary values, we need to be able to transform each of those values into a normalized form. 

Without the `multival` parameter, the whole value of the field was normalized, removing any multivalue delimiters. This normalized value would then not match to any authority lookups. 

The new `multival` parameter defaults to `false` for backward compatibility, and a `delim` parameter is also added for specifying how to split the field into separate values. 