### PR TITLE
do not run the same dependency more than once

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -34,6 +34,7 @@ These changes are merged into the `main` branch but have not yet been tagged as 
 * `Merge::ConstantValues` transform added. In https://github.com/lyrasis/kiba-extend/pull/84[PR#84]
 
 ==== Changed
+* BUGFIX: No longer runs the same dependency job multiple times. In https://github.com/lyrasis/kiba-extend/pull/89[PR#89]
 * In `Merge::ConstantValueConditional` transform, lambda Proc is passed in as `condition`, rather than `conditions`. In https://github.com/lyrasis/kiba-extend/pull/88[PR#88]
 * If source data is an ISO 3166 code, `Cspace::AddressCountry` passes that value through to target. Adds some more lookup keys to support client data set. In https://github.com/lyrasis/kiba-extend/pull/87[PR#87]
 * Deprecates `FilterRows::FieldValueGreaterThan`. In https://github.com/lyrasis/kiba-extend/pull/86[PR#86]

--- a/lib/kiba/extend/jobs/runner.rb
+++ b/lib/kiba/extend/jobs/runner.rb
@@ -83,10 +83,12 @@ module Kiba
         end
 
         def handle_requirements
-          [@files[:source], @files[:lookup]].compact.flatten.map(&:required).compact.each do |creator|
-            creator.call
+          [@files[:source], @files[:lookup]].compact.flatten.compact.each do |registered|
+            next unless  registered.required
+
+            registered.required.call
           end
-          
+
           check_requirements
         rescue MissingDependencyError => err
           puts "JOB FAILED: DEPENDENCY ERROR IN: #{err.calling_job}"


### PR DESCRIPTION
If dependency was defined as a source and lookup in the same job, previously it would be run twice. 

That no longer happens. We check whether the required file (the destination/path of the dependency job) exists directly before calling each job, instead of when generating an array of dependencies to be called (at that point, none have been called so dependent files are missing)