### PR TITLE
Bugfix for Reshape::FieldsToFieldGroupWithConstant

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -43,6 +43,9 @@ These changes are merged into the `main` branch but have not yet been tagged as 
 
 ==== Changed
 
+==== Bugfixes
+* `Reshape::FieldsToFieldGroupWithConstant` now works with single source fields (i.e. listed in `fieldmap` param) with nil values
+
 ==== Deleted
 
 ==== To be deprecated/Will break in a future version

--- a/lib/kiba/extend/transforms/reshape/fields_to_field_group_with_constant.rb
+++ b/lib/kiba/extend/transforms/reshape/fields_to_field_group_with_constant.rb
@@ -249,7 +249,10 @@ module Kiba
           
           def find_max_vals(row)
             if renamed.length == 1
-              row[renamed.first].split(delim, -1).length
+              val = row[renamed.first]
+              return 0 if val.blank?
+              
+              val.split(delim, -1).length
             else
               value_getter.call(row)
                 .values

--- a/spec/kiba/extend/transforms/reshape/fields_to_field_group_with_constant_spec.rb
+++ b/spec/kiba/extend/transforms/reshape/fields_to_field_group_with_constant_spec.rb
@@ -164,4 +164,37 @@ RSpec.describe Kiba::Extend::Transforms::Reshape::FieldsToFieldGroupWithConstant
       expect(result).to eq(expected)
     end
   end
+
+  context 'with single source field' do
+    let(:input) do
+      [
+        {note: 'foo'},
+        {note: nil},
+        {note: ''},
+        {note: 'foo|bar'}
+      ]
+    end
+
+    let(:params) do
+      {
+        fieldmap: {note: :a_note},
+        constant_target: :a_type,
+        constant_value: 'a thing',
+        replace_empty: false
+      }
+    end
+    
+    let(:expected) do
+      [
+        {a_type: 'a thing', a_note: 'foo'},
+        {a_type: nil, a_note: nil},
+        {a_type: nil, a_note: nil},
+        {a_type: 'a thing|a thing', a_note: 'foo|bar'}
+      ]
+    end
+
+    it 'reshapes the columns as specified' do
+      expect(result).to eq(expected)
+    end
+  end
 end


### PR DESCRIPTION
With replace_empty: false, nil field values would not get replaced with
Strings, causing the private :find_max_vals method to throw an error.