### PR TITLE
Refactor thor commands

### DIFF
--- a/lib/kiba/extend/command.rb
+++ b/lib/kiba/extend/command.rb
@@ -3,8 +3,6 @@
 module Kiba
   module Extend
     # Modules and classes defining commands
-    #
-    # This structure follows the pattern set out in {https://github.com/thbar/kiba-common kiba-common}
     module Command
     end
   end

--- a/lib/kiba/extend/command.rb
+++ b/lib/kiba/extend/command.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Kiba
+  module Extend
+    # Modules and classes defining commands
+    #
+    # This structure follows the pattern set out in {https://github.com/thbar/kiba-common kiba-common}
+    module Command
+    end
+  end
+end

--- a/lib/kiba/extend/command/reg.rb
+++ b/lib/kiba/extend/command/reg.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Kiba
+  module Extend
+    module Command
+      module Reg
+        module_function
+        
+        def list
+          puts Kiba::Extend::Registry::RegistryList.new
+        end
+
+        def tags
+          Kiba::Extend.registry.entries.map(&:tags)
+            .compact
+            .reject(&:empty?)
+            .flatten
+            .uniq
+            .sort
+        end
+
+        def validate
+          Kiba::Extend::Registry::RegistryValidator.new.report
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/extend/command/reg/list.rb
+++ b/lib/kiba/extend/command/reg/list.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Kiba
+  module Extend
+    module Command
+      module Reg
+        module List
+          
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/extend/command/run.rb
+++ b/lib/kiba/extend/command/run.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Kiba
+  module Extend
+    module Command
+      module Run
+        extend Runnable
+        module_function
+
+        # @param key [Symbol, String] registry key for job, i.e. prep__loan_purposes
+        def job(key)
+          run_job(key)
+        end
+      end
+    end
+  end
+end

--- a/lib/kiba/extend/command/runnable.rb
+++ b/lib/kiba/extend/command/runnable.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+module Kiba
+  module Extend
+    module Command
+      module Runnable
+        module_function
+        
+        def resolve_job(key)
+          Kiba::Extend.registry.resolve(key)
+        rescue Dry::Container::KeyError
+          puts "No job with key: #{key}"
+          :failure
+        end
+
+        def resolve_creator(job)
+          creator = job.creator
+          return creator if creator
+
+          puts "No creator method for #{job.key}"
+          :failure
+        end
+
+        def run_job(key)
+          job = resolve_job(key)
+          return if job == :failure
+
+          creator = resolve_creator(job)
+          return if creator == :failure
+
+          creator.call
+        end
+      end
+    end
+  end
+end

--- a/lib/tasks/jobs/tagged.thor
+++ b/lib/tasks/jobs/tagged.thor
@@ -15,6 +15,6 @@ LONG
 
     return unless options[:run]
 
-    result.map(&:key).each{ |key| run_job(key) }
+    run_jobs(result.map(&:key))
   end
 end

--- a/lib/tasks/jobs/tagged_and.thor
+++ b/lib/tasks/jobs/tagged_and.thor
@@ -18,6 +18,6 @@ LONG
 
     return unless options[:run]
 
-    result.map(&:key).each{ |key| run_job(key) }
+    run_jobs(result.map(&:key))
   end
 end

--- a/lib/tasks/jobs/tagged_or.thor
+++ b/lib/tasks/jobs/tagged_or.thor
@@ -18,6 +18,6 @@ LONG
 
     return unless options[:run]
 
-    result.map(&:key).each{ |key| run_job(key) }
+    run_jobs(result.map(&:key))
   end
 end

--- a/lib/tasks/reg.thor
+++ b/lib/tasks/reg.thor
@@ -4,24 +4,16 @@ require 'thor'
 class Reg < Thor  
   desc 'list', 'List all entries in file registry with file key, path, description, and creator'
   def list
-    puts Kiba::Extend::Registry::RegistryList.new
+    Kiba::Extend::Command::Reg.list
   end
 
   desc 'tags', 'List tags used in the registry'
   def tags
-    tags = []
-    Kiba::Extend.registry.entries.each do |entry|
-      entrytags = entry.tags
-      next if entrytags.blank?
-
-      tags << entrytags
-    end
-    clean = tags.flatten.sort.uniq
-    puts clean
+    puts Kiba::Extend::Command::Reg.tags
   end
 
   desc 'validate', 'List entries in file registry with errors and warnings'
   def validate
-    Kiba::Extend::Registry::RegistryValidator.new.report
+    Kiba::Extend::Command::Reg.validate
   end
 end

--- a/lib/tasks/run.thor
+++ b/lib/tasks/run.thor
@@ -1,5 +1,5 @@
-require_relative 'runnable'
+# require_relative 'runnable'
 
-class Run < Runnable
+# class Run < Runnable
 
-end
+# end

--- a/lib/tasks/run/job.thor
+++ b/lib/tasks/run/job.thor
@@ -5,6 +5,6 @@ class Run < Runnable
   
   def job(key)
     preprocess_options
-    run_job(key)
+    Kiba::Extend::Command::Run.job(key)
   end
 end

--- a/lib/tasks/run/jobs.thor
+++ b/lib/tasks/run/jobs.thor
@@ -7,6 +7,6 @@ class Run < Runnable
 
   def jobs
     preprocess_options
-    options[:keys].each{ |key| run_job(key) }
+    options[:keys].each{ |key| Kiba::Extend::Command::Run.job(key) }
   end
 end

--- a/lib/tasks/run/jobs.thor
+++ b/lib/tasks/run/jobs.thor
@@ -6,7 +6,6 @@ class Run < Runnable
          desc: 'Registry keys for the job to run'
 
   def jobs
-    preprocess_options
-    options[:keys].each{ |key| Kiba::Extend::Command::Run.job(key) }
+    run_jobs(options[:keys])
   end
 end

--- a/lib/tasks/runnable.rb
+++ b/lib/tasks/runnable.rb
@@ -17,28 +17,8 @@ class Runnable < Thor
     Kiba::Extend.config.job.verbosity = options[:verbosity].to_sym
   end
 
-  # def resolve_job(key)
-  #   Kiba::Extend.registry.resolve(key)
-  # rescue Dry::Container::KeyError
-  #   puts "No job with key: #{key}"
-  #   :failure
-  # end
-
-  # def resolve_creator(job)
-  #   creator = job.creator
-  #   return creator if creator
-
-  #   puts "No creator method for #{job.key}"
-  #   :failure
-  # end
-
-  # def run_job(key)
-  #   job = resolve_job(key)
-  #   return if job == :failure
-
-  #   creator = resolve_creator(job)
-  #   return if creator == :failure
-
-  #   creator.call
-  # end
+  def run_jobs(keys)
+    preprocess_options
+    keys.each{ |key| Kiba::Extend::Command::Run.job(key) }
+  end
 end

--- a/lib/tasks/runnable.rb
+++ b/lib/tasks/runnable.rb
@@ -17,28 +17,28 @@ class Runnable < Thor
     Kiba::Extend.config.job.verbosity = options[:verbosity].to_sym
   end
 
-  def resolve_job(key)
-    Kiba::Extend.registry.resolve(key)
-  rescue Dry::Container::KeyError
-    puts "No job with key: #{key}"
-    :failure
-  end
+  # def resolve_job(key)
+  #   Kiba::Extend.registry.resolve(key)
+  # rescue Dry::Container::KeyError
+  #   puts "No job with key: #{key}"
+  #   :failure
+  # end
 
-  def resolve_creator(job)
-    creator = job.creator
-    return creator if creator
+  # def resolve_creator(job)
+  #   creator = job.creator
+  #   return creator if creator
 
-    puts "No creator method for #{job.key}"
-    :failure
-  end
+  #   puts "No creator method for #{job.key}"
+  #   :failure
+  # end
 
-  def run_job(key)
-    job = resolve_job(key)
-    return if job == :failure
+  # def run_job(key)
+  #   job = resolve_job(key)
+  #   return if job == :failure
 
-    creator = resolve_creator(job)
-    return if creator == :failure
+  #   creator = resolve_creator(job)
+  #   return if creator == :failure
 
-    creator.call
-  end
+  #   creator.call
+  # end
 end


### PR DESCRIPTION
Extracts some of the the functional/logical code from thor tasks to the `Kiba::Extend::Command` namespace so that those commands can be run by other code in the kiba-extend application or projects using it. This leaves the thor tasks more purely a CLI layer.  