### PR TITLE
Raise MultiRowLookup::EmptyFieldmap error if fieldmap is empty

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -40,6 +40,7 @@ These changes are merged into the `main` branch, but have not been released. Aft
 === Changed
 
 === Bugfixes
+* Catch `Merge::MultiRowLookup` transform created with empty `fieldmap` and raise error on initialization, rather than letting it blow up `Utils::Fieldset` later (PR#127)
 * Fix https://github.com/lyrasis/kiba-extend/issues/121[#121] (PR#122)
 
 === Deleted

--- a/lib/kiba/extend/transforms/merge/multi_row_lookup.rb
+++ b/lib/kiba/extend/transforms/merge/multi_row_lookup.rb
@@ -20,6 +20,8 @@ module Kiba
             attr_reader :lookup
           end
 
+          class EmptyFieldmap < Kiba::Extend::Error; end
+
           # @param fieldmap [Hash{Symbol => Symbol}] key = field in source row to merge lookup data into;
           #   value = field from lookup table whose value maps into target field
           # @param lookup [Hash] created by Utils::LookupHash. If you have registered a job as a lookup,
@@ -54,6 +56,8 @@ module Kiba
                          conditions: {}, multikey: false, delim: Kiba::Extend.delim, null_placeholder: nil,
                          sorter: nil)
             @fieldmap = fieldmap # hash of looked-up values to merge in for each merged-in row
+            fail EmptyFieldmap if fieldmap.empty?
+
             @constantmap = constantmap # hash of constants to add for each merged-in row
             @lookup = lookup # lookuphash; should be created with csv_to_multi_hash
             fail LookupTypeError.new(lookup) unless lookup.is_a?(Hash)

--- a/spec/kiba/extend/transforms/merge/multi_row_lookup_spec.rb
+++ b/spec/kiba/extend/transforms/merge/multi_row_lookup_spec.rb
@@ -68,6 +68,28 @@ RSpec.describe Kiba::Extend::Transforms::Merge::MultiRowLookup do
       expect(result).to eq(expected)
     end
 
+    context 'with empty fieldhash' do
+      let(:transforms) do
+        Kiba.job_segment do
+          lkup_table = [
+            {:id=>"4", :date=>"", :treatment=>"nail trim"},
+            {:id=>"2", :date=>"2019-08-01", :treatment=>"hatch"}
+          ]
+          transform Merge::MultiRowLookup,
+            fieldmap: {},
+            keycolumn: :id,
+            lookup: Lookup.enum_to_hash(enum: lkup_table, keycolumn: :id),
+            delim: '|'
+        end
+      end
+
+      it 'raises error' do
+        expect{ result }.to raise_error(
+          Kiba::Extend::Transforms::Merge::MultiRowLookup::EmptyFieldmap
+        )
+      end
+    end
+
     context 'with sorter specified' do
       let(:transforms) do
         Kiba.job_segment do
@@ -177,7 +199,7 @@ RSpec.describe Kiba::Extend::Transforms::Merge::MultiRowLookup do
         expect(result).to eq(expected)
       end
     end
-    
+
     context 'with constantmap specified' do
       let(:transforms) do
         Kiba.job_segment do
@@ -205,7 +227,7 @@ RSpec.describe Kiba::Extend::Transforms::Merge::MultiRowLookup do
             constantmap: { by: 'kms', loc: 'The Thicket' }
         end
       end
-      
+
       let(:expected) do
         [
           { id: '1', name: 'Weddy', sex: 'm', source: 'adopted',
@@ -263,40 +285,40 @@ RSpec.describe Kiba::Extend::Transforms::Merge::MultiRowLookup do
         { single: nil, doubles: nil, triples: nil }
       ]
     end
-    
+
     let(:lookup) { Lookup.csv_to_multi_hash(file: lookup_csv, csvopt: Kiba::Extend.csvopts, keycolumn: :single) }
 
     let(:transforms) do
       Kiba.job_segment do
         transform Merge::MultiRowLookup,
-            fieldmap: {
-              doubles: :double,
-              triples: :triple
-            },
-            keycolumn: :single,
-            multikey: true,
-            delim: '|',
-            lookup: {
-              "a"=>[
-                {:single=>"a", :double=>"aa", :triple=>"aaa"}
-              ],
-              "b"=>[
-                {:single=>"b", :double=>"bb", :triple=>"bbb"},
-                {:single=>"b", :double=>"beebee", :triple=>""}
-              ],
-              "c"=>[
-                {:single=>"c", :double=>"cc", :triple=>"ccc"}
-              ],
-              "d"=>[
-                {:single=>"d", :double=>"dd", :triple=>"ddd"}
-              ],
-              "e"=>[
-                {:single=>"e", :double=>"ee", :triple=>"eee"}
-              ],
-              "g"=>[
-                {:single=>"g", :double=>"", :triple=>"ggg"}
-              ]
-            }
+          fieldmap: {
+            doubles: :double,
+            triples: :triple
+          },
+          keycolumn: :single,
+          multikey: true,
+          delim: '|',
+          lookup: {
+            "a"=>[
+              {:single=>"a", :double=>"aa", :triple=>"aaa"}
+            ],
+            "b"=>[
+              {:single=>"b", :double=>"bb", :triple=>"bbb"},
+              {:single=>"b", :double=>"beebee", :triple=>""}
+            ],
+            "c"=>[
+              {:single=>"c", :double=>"cc", :triple=>"ccc"}
+            ],
+            "d"=>[
+              {:single=>"d", :double=>"dd", :triple=>"ddd"}
+            ],
+            "e"=>[
+              {:single=>"e", :double=>"ee", :triple=>"eee"}
+            ],
+            "g"=>[
+              {:single=>"g", :double=>"", :triple=>"ggg"}
+            ]
+          }
       end
     end
 
@@ -318,38 +340,38 @@ RSpec.describe Kiba::Extend::Transforms::Merge::MultiRowLookup do
       let(:transforms) do
         Kiba.job_segment do
           transform Merge::MultiRowLookup,
-              fieldmap: {
-                doubles: :double,
-                triples: :triple
-              },
-              lookup: {
-                "a"=>[
-                  {:single=>"a", :double=>"aa", :triple=>"aaa"}
-                ],
-                "b"=>[
-                  {:single=>"b", :double=>"bb", :triple=>"bbb"},
-                  {:single=>"b", :double=>"beebee", :triple=>""}
-                ],
-                "c"=>[
-                  {:single=>"c", :double=>"cc", :triple=>"ccc"}
-                ],
-                "d"=>[
-                  {:single=>"d", :double=>"dd", :triple=>"ddd"}
-                ],
-                "e"=>[
-                  {:single=>"e", :double=>"ee", :triple=>"eee"}
-                ],
-                "g"=>[
-                  {:single=>"g", :double=>"", :triple=>"ggg"}
-                ]
-              },
-              keycolumn: :single,
-              multikey: true,
-              delim: '|',
-              constantmap: { quad: 4, pent: 5 }
+            fieldmap: {
+              doubles: :double,
+              triples: :triple
+            },
+            lookup: {
+              "a"=>[
+                {:single=>"a", :double=>"aa", :triple=>"aaa"}
+              ],
+              "b"=>[
+                {:single=>"b", :double=>"bb", :triple=>"bbb"},
+                {:single=>"b", :double=>"beebee", :triple=>""}
+              ],
+              "c"=>[
+                {:single=>"c", :double=>"cc", :triple=>"ccc"}
+              ],
+              "d"=>[
+                {:single=>"d", :double=>"dd", :triple=>"ddd"}
+              ],
+              "e"=>[
+                {:single=>"e", :double=>"ee", :triple=>"eee"}
+              ],
+              "g"=>[
+                {:single=>"g", :double=>"", :triple=>"ggg"}
+              ]
+            },
+            keycolumn: :single,
+            multikey: true,
+            delim: '|',
+            constantmap: { quad: 4, pent: 5 }
         end
       end
-      
+
       it 'merges specified constant values into specified fields for each row merged' do
         expect(result).to eq(expected)
       end


### PR DESCRIPTION
This is unusual if manually writing transforms, but I ran into it in the kiba-tms project where the fieldmaps are sometimes generated based on client config.

If the issue isn't caught here, you end up getting a weird, opaque error from Utils::Fieldset instead.