### PR TITLE
OrgNameChecker transforms helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,5 @@
 .byebug_history
 
 **/.~lock*coverage
-
+**/.DS_Store
 spec/fixtures/*.mrk

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -46,7 +46,7 @@ These changes are merged into the `main` branch, but have not been released. Aft
 * `Split::PublicationStatement` transform (PR#142)
 * `CombineValues::FromFieldWithDelimiter` can now take `sources: :all`, and will provide space as a default `delim` if not provided  (PR#147)
 * `CombineValues::FromFieldWithDelimiter` can now take `delete_sources` and `prepend_source_field_name` args (PR#147)
-
+* `Transforms::Helpers::OrgNameChecker`
 === Changed
 * Transforms that take an `action` argument now mix in the new `ActionArgumentable` module and validate the argument values in a consistent way (PR#138)
 * Name and role term values extracted from MARC data by subclasses of `Transforms::Marc::ExtractBaseNameData` are run through `Utils::MarcNameCleaner` and `Utils::MarcRoleTermCleaner` (PR#141)

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -46,7 +46,8 @@ These changes are merged into the `main` branch, but have not been released. Aft
 * `Split::PublicationStatement` transform (PR#142)
 * `CombineValues::FromFieldWithDelimiter` can now take `sources: :all`, and will provide space as a default `delim` if not provided  (PR#147)
 * `CombineValues::FromFieldWithDelimiter` can now take `delete_sources` and `prepend_source_field_name` args (PR#147)
-* `Transforms::Helpers::OrgNameChecker`
+* `Transforms::Helpers::OrgNameChecker` (PR#148)
+
 === Changed
 * Transforms that take an `action` argument now mix in the new `ActionArgumentable` module and validate the argument values in a consistent way (PR#138)
 * Name and role term values extracted from MARC data by subclasses of `Transforms::Marc::ExtractBaseNameData` are run through `Utils::MarcNameCleaner` and `Utils::MarcRoleTermCleaner` (PR#141)

--- a/lib/kiba/extend/transforms/helpers/org_name_checker.rb
+++ b/lib/kiba/extend/transforms/helpers/org_name_checker.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+module Kiba
+  module Extend
+    module Transforms
+      module Helpers
+        # Returns true/false indicating whether given value matches any
+        #   given or added patterns. Used on a list of names and name-like
+        #   values, this works ok. Used on a list of subject like terms or
+        #   on freetext, be wary of false positives (though the patterns and
+        #   the duplicative anchoring matching tries to avoid matching
+        #   subject-like terms
+        class OrgNameChecker
+          class << self
+            def call(
+              value:,
+              added_patterns: [],
+              family_is_org: false
+            )
+              self.new(
+                added_patterns: added_patterns,
+                family_is_org: family_is_org
+              ).call(value)
+            end
+          end
+
+          # rubocop:disable Layout/LineLength
+          DEFAULT_PATTERNS = [
+              / LLC/i,
+              / co$/i,
+              / co\./i,
+              / corp\.$/i,
+              / dept\.?$/i,
+              /dept\./i,
+              / inc$/i,
+              /inc\./i,
+              /^\w+ & \w+$/,
+              /^(\w+,? )+& \w+$/,
+              /'s$/,
+              # military
+              /^(artillery|brigade|infantry|regiment) /i,
+              / (artillery|brigade|infantry|regiment) /i,
+              / (artillery|brigade|infantry|regiment)$/i,
+              # organizational units
+              /(inter|multi)?national/i,
+              /^(administration|assembly|bureau|commission|committee|council|department|division|federation|office) /i,
+              / (administration|assembly|bureau|commission|committee|council|department|division|federation|office) /i,
+              / (administration|assembly|bureau|commission|committee|council|department|division|federation|office)$/i,
+              # education
+              /^(academy|college|institute|program|university|school) /i,
+              / (academy|college|institute|program|university|school) /i,
+              / (academy|college|institute|program|university|school)$/i,
+              / (elementary|middle|primary|high)$/i,
+              # health-related
+              /^(hospital|nursing home|pharmacy) /i,
+              / (hospital|nursing home|pharmacy) /i,
+              / (hospital|nursing home|pharmacy)$/i,
+              # governmental
+              /^(agency|court of|general assembly|senate|tribe) /i,
+              / (agency|court of|general assembly|senate|tribe)\.? /i,
+              / (agency|court of|general assembly|senate|tribe)$/i,
+              # non-profity terms
+              /^(alliance|board of|foundation|program|task ?force) /i,
+              / (alliance|board of|foundation|program|task ?force) /i,
+              / (alliance|board of|foundation|program|task ?force)$/i,
+              / (network|project|services?)$/i,
+              # corporate/company name terms
+              /^(company|consultant(s|)|corporation|group|incorporated|service) /i,
+              / (company|consultant(s|)|corporation|group|incorporated|service) /i,
+              / (company|consultant(s|)|corporation|group|incorporated|service)$/i,
+              /\.com$/,
+              # glam/cultural institutions
+              /^(band|centers?|ensemble|gallery|library|museum|observatory|orchestra|studio|theat(er|re)) /i,
+              / (band|centers?|ensemble|gallery|library|museum|observatory|orchestra|studio|theat(er|re)) /i,
+              / (band|centers?|ensemble|gallery|library|museum|observatory|orchestra|studio|theat(er|re))$/i,
+              # clubs/groups
+              /^(association|choir|club|fraternity|friends of the|legion|league|society|sorority|team) /i,
+              / (association|choir|club|fraternity|friends of the|legion|league|society|sorority|team) /i,
+              / (association|choir|club|fraternity|friends of the|legion|league|society|sorority|team)$/i,
+              # events
+              /^(games|olympics) /i,
+              / (games|olympics) /i,
+              / (games|olympics)$/i,
+              # transportation
+              /^(airport|depot|rail(road|way)) /i,
+              / (airport|depot|rail(road|way)) /i,
+              / (airport|depot|rail(road|way))$/i,
+              # food and drink
+              /^(brewer(ies|y)|cafe|farm|grocer(ies|y)|restaurant|saloon|tavern) /i,
+              / (brewer(ies|y)|cafe|farm|grocer(ies|y)|restaurant|saloon|tavern) /i,
+              / (brewer(ies|y)|cafe|farm|grocer(ies|y)|restaurant|saloon|tavern)$/i,
+              # areas/types of business
+              /publish/i,
+              /^(auto(motive|)|hotel(s)|inn|insurance|plumb(ers|ing)|roofing|shop|store) /i,
+              / (auto(motive|)|hotel(s)|inn|insurance|plumb(ers|ing)|roofing|shop|store) /i,
+              / (auto(motive|)|hotel(s)|inn|insurance|plumb(ers|ing)|roofing|shop|store)$/i,
+            ]
+
+          FAMILY_PATTERNS = [
+            / famil(ies|y)/i
+          ]
+          # rubocop:enable Layout/LineLength
+
+          # @param added_patterns [Array<Regexp>] non-standard regexp to check
+          #   against. Best practice is to add these to this helper via a pull
+          #   request if you think they generally indicate organization-ness
+          # @param family_is_org [Boolean] whether names with terms indicating
+          #   family-ness are treated as organizations (yes for CollectionSpace,
+          #   no for applications that have a Family name type)
+          def initialize(added_patterns: [], family_is_org: false)
+            base = DEFAULT_PATTERNS + added_patterns
+            @patterns = family_is_org ? base + FAMILY_PATTERNS : base
+          end
+
+          # @param value [String]
+          # @return [true] if `value` matches an org pattern
+          # @return [false] otherwise
+          def call(value)
+            return false if value.blank?
+            return true if patterns.any? { |pattern| value.match?(pattern) }
+
+            false
+          end
+
+          private
+
+          attr_reader :patterns
+        end
+      end
+    end
+  end
+end

--- a/spec/kiba/extend/transforms/helpers/org_name_checker_spec.rb
+++ b/spec/kiba/extend/transforms/helpers/org_name_checker_spec.rb
@@ -1,0 +1,61 @@
+RSpec.describe Kiba::Extend::Transforms::Helpers::OrgNameChecker do
+  subject(:checker){ described_class.new(**params) }
+
+  describe '#call' do
+    let(:results){ vals.keys.map{ |val| [val, checker.call(val)] }.to_h }
+    let(:params){ {} }
+
+
+    context 'with default params' do
+      let(:vals) do
+        {
+          "Acme, LLC."=>true,
+          "Acme Co"=>true,
+          "Acme Co."=>true,
+          "Co Cooper"=>false,
+          "Art dept."=>true,
+          "Art Dept"=>true,
+          "Art department"=>true,
+          "Dept. of the Interior"=>true,
+          "Crimethinc"=>false,
+          "Acme, Inc"=>true,
+          "Acme, Inc."=>true,
+          "Napo & El"=>true,
+          "Hops, Munstead, & Vern"=>true,
+          "Smith family"=>false,
+          "Plumbing"=>false
+        }
+      end
+
+      it 'returns expected' do
+        expect(results).to eq(vals)
+      end
+    end
+
+    context 'with added pattern' do
+      let(:params){ {added_patterns: [/inc$/]} }
+      let(:vals) do
+        {
+          "Crimethinc"=>true,
+        }
+      end
+
+      it 'returns expected' do
+        expect(results).to eq(vals)
+      end
+    end
+
+    context 'with family_is_org' do
+      let(:params){ {family_is_org: true} }
+      let(:vals) do
+        {
+          "Smith Family"=>true,
+        }
+      end
+
+      it 'returns expected' do
+        expect(results).to eq(vals)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds a Transforms::Helper `call`able service class that can be used directly or in future transforms.