### PR TITLE
Job modes and job duration

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -49,6 +49,8 @@ These changes are merged into the `main` branch, but have not been released. Aft
 * `Transforms::Helpers::OrgNameChecker` (PR#148)
 * `Kiba::Extend::Job.output?` convenience method (PR#150)
 * `Sort::ByFieldValue` transform (PR#151)
+* `:mode` parameter to `Jobs::BaseJob` (PR#154)
+* Job duration report (added to normal and verbose job run) (PR#154)
 
 === Changed
 * Transforms that take an `action` argument now mix in the new `ActionArgumentable` module and validate the argument values in a consistent way (PR#138)

--- a/lib/kiba/extend/jobs/base_job.rb
+++ b/lib/kiba/extend/jobs/base_job.rb
@@ -21,7 +21,9 @@ module Kiba
         # @param files [Hash]
         # @param transformer [Kiba::Control]
         def initialize(files:, transformer:)
-          @dependency = true if caller(2, 5).join(' ')['block in handle_requirements']
+          if caller(2, 5).join(' ')['block in handle_requirements']
+            @dependency = true
+          end
           extend DependencyJob if @dependency
 
           @files = setup_files(files)
@@ -52,7 +54,8 @@ module Kiba
           @files[:destination].first.data
         end
 
-        # Replace file key names with registered_source/lookup/destination objects dynamically
+        # Replace file key names with registered_source/lookup/destination
+        #   objects dynamically
         def setup_files(files)
           tmp = {}
           files.each do |type, arr|

--- a/lib/kiba/extend/jobs/reporter.rb
+++ b/lib/kiba/extend/jobs/reporter.rb
@@ -6,6 +6,7 @@ module Kiba
       # Mixin methods for reporting
       module Reporter
         def report_run_start
+          @start = Time.now
           case Kiba::Extend.job_verbosity
           when :verbose
             verbose_start
@@ -19,6 +20,7 @@ module Kiba
         end
 
         def report_run_end
+          @duration = Time.now - @start
           case Kiba::Extend.job_verbosity
           when :verbose
             verbose_end
@@ -52,7 +54,7 @@ module Kiba
         end
 
         def verbose_end
-          puts "\n#{job_data.key} complete"
+          puts "\n#{job_data.key} complete (#{get_duration})"
           puts "#{row_report} written to #{job_data.path}"
           puts "NOTE: #{job_data.message.upcase}" if job_data.message
           puts '-=-=-=-=-=-=-=-=-=-=-=-'
@@ -60,7 +62,7 @@ module Kiba
         end
 
         def normal_end
-          puts "\n#{row_report} written to #{job_data.path}"
+          puts "\n#{row_report} written to #{job_data.path} in #{get_duration}"
           puts "NOTE: #{job_data.message.upcase}" if job_data.message
           puts '-=-=-=-=-=-=-=-=-=-=-=-'
           puts ''
@@ -97,7 +99,7 @@ module Kiba
         end
 
         def row_report
-          "#{context.instance_variable_get(:@outrows)} of #{context.instance_variable_get(:@srcrows)} rows"
+          "#{outrows} of #{srcrows}"
         end
 
         def start_label
@@ -113,6 +115,14 @@ module Kiba
           return unless tags
 
           "tags: [#{tags.join(', ')}]"
+        end
+
+        def get_duration
+          minutes = (@duration / 60).floor
+          seconds = (@duration - (minutes * 60)).ceil
+          "#{minutes}m #{seconds}s"
+        rescue
+          ""
         end
       end
     end

--- a/lib/kiba/extend/jobs/runner.rb
+++ b/lib/kiba/extend/jobs/runner.rb
@@ -86,11 +86,14 @@ module Kiba
         end
 
         def handle_requirements
-          [@files[:source], @files[:lookup]].compact.flatten.compact.each do |registered|
-            next unless registered.required
+          [@files[:source], @files[:lookup]].compact
+            .flatten
+            .compact
+            .each do |registered|
+              next unless registered.required
 
-            registered.required.call
-          end
+              registered.required.call
+            end
 
           check_requirements
         rescue MissingDependencyError => err


### PR DESCRIPTION
Adds a `mode` parameter defaulting to `:run` on the `BaseJob` class. 

The other options are: 
- :info - Returns job object with source, lookups, and destination file info, but does not check for the presence of source or lookup dependencies, or run the jobs to create them. (Planned use is in creating job dependency graphs)
- :setup - Returns job object with source, lookups, and destination file info, checks for the presence of source or lookup dependencies, and run the jobs to create them if necessary. Use: to include jobs that are not based on Kiba::Extend transforms in your pipelines

Also: adds job run duration to the normal and verbose output for jobs. 