### PR TITLE
Make Fingerprint::MergeCorrected multi-row

### DIFF
--- a/lib/kiba/extend/transforms/fingerprint/flag_changed.rb
+++ b/lib/kiba/extend/transforms/fingerprint/flag_changed.rb
@@ -86,7 +86,7 @@ module Kiba
           #   added to rows
           # @param delete_fp [Boolean] whether to delete the given fingerprint
           #   field
-          # @parm empty_equals_nil [Boolean] whether to treat blank and nil
+          # @param empty_equals_nil [Boolean] whether to treat blank and nil
           #   values as equal
           def initialize(fingerprint:, source_fields:, target:, delim: "␟",
                          prefix: "fp", delete_fp: false, empty_equals_nil: true)


### PR DESCRIPTION
Initial iteration of this transform only applied the first correction row found in the lookup. Now it applies all correction rows returned via the lookup, in order returned. 