### PR TITLE
gh-162 Fix failure of Delete::EmptyFields when no source rows

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -68,6 +68,7 @@ These changes are merged into the `main` branch, but have not been released. Aft
 * Fixes issue where job registry entry with a Marc source and CSV destination could not be used as a source or lookup in jobs (PR#137)
 * Fixes issue in `StringValue::ToArray` transform where delim=nil was not correctly being calculated (PR#145)
 * Fixes https://github.com/lyrasis/kiba-extend/issues/152[#152]: Fingerprint::Decode error: Encoding::CompatibilityError: incompatible character encodings: ASCII-8BIT and UTF-8 (PR#153)
+* Fixes https://github.com/lyrasis/kiba-extend/issues/162[#162]: failure of `Delete::EmptyFields` transform when passed a source with no rows
 
 === Deleted
 

--- a/lib/kiba/extend/transforms/delete/empty_fields.rb
+++ b/lib/kiba/extend/transforms/delete/empty_fields.rb
@@ -128,6 +128,8 @@ module Kiba
           end
 
           def close
+            return if rows.empty?
+
             to_delete = rows.first.keys - pop_fields.keys
             rows.each do |row|
               to_delete.each{ |field| row.delete(field) }

--- a/spec/kiba/extend/transforms/delete/empty_fields_spec.rb
+++ b/spec/kiba/extend/transforms/delete/empty_fields_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe Kiba::Extend::Transforms::Delete::EmptyFields do  
+RSpec.describe Kiba::Extend::Transforms::Delete::EmptyFields do
   let(:accumulator){ [] }
   let(:test_job){ Helpers::TestJob.new(input: input, accumulator: accumulator, transforms: transforms) }
   let(:result){ test_job.accumulator }
@@ -113,6 +113,22 @@ RSpec.describe Kiba::Extend::Transforms::Delete::EmptyFields do
       it 'transforms as expected' do
         expect(result).to eq(expected)
       end
+    end
+  end
+
+  context 'with empty input source' do
+    let(:input){ [] }
+
+    let(:expected){ [] }
+
+    let(:transforms) do
+      Kiba.job_segment do
+        transform Delete::EmptyFields
+      end
+    end
+
+    it 'transforms as expected' do
+      expect(result).to eq(expected)
     end
   end
 end


### PR DESCRIPTION
Resolves #162 