### PR TITLE
Adds a test to try to reproduce #173 (Fingerprint::MergeCorrected)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /docs
 /coverage/
 /pkg/
+/.ruby-version
 /spec/reports/
 /spec/tmp/
 /tmp/
@@ -15,5 +16,4 @@
 **/.~lock*coverage
 **/.DS_Store
 spec/fixtures/*.mrk
-.rubocop-https---raw-githubusercontent-com-kspurgin-code-quality-main-configurations-rubocop-standard-override-yml
-.rubocop-https---raw-githubusercontent-com-kspurgin-code-quality-main-configurations-rubocop-standard-yml
+.rubocop-https*

--- a/lib/kiba/extend/transforms/fingerprint/merge_corrected.rb
+++ b/lib/kiba/extend/transforms/fingerprint/merge_corrected.rb
@@ -48,6 +48,42 @@ module Kiba
         #     {fp: "4", a: 'ant', b: 'bear'},
         #   ]
         #   expect(result).to eq(expected)
+        #
+        # @example With tag_affected_in
+        #   # Used in pipeline as:
+        #   # transform Fingerprint::MergeCorrected,
+        #   #   keycolumn: :fp,
+        #   #   lookup: lookup,
+        #   #   todofield: :corrected,
+        #   #   tag_affected_in: :corr
+        #   lookup = {
+        #     "1"=>[{key: "1", a: "apps", b: nil, corrected: "a|b"}],
+        #     "2"=>[{key: "2", a: "apple", b: "bee", corrected: "b"},
+        #           {key: "2", a: "apples", b: "bee", corrected: "a"}],
+        #     "3"=>[{key: "3", a: "apple", b: "bees", corrected: nil}]
+        #   }
+        #   xform = Fingerprint::MergeCorrected.new(
+        #     keycolumn: :fp,
+        #     lookup: lookup,
+        #     todofield: :corrected,
+        #     tag_affected_in: :corr
+        #   )
+        #   input = [
+        #     {fp: "1", a: 'ant', b: 'bear'},
+        #     {fp: "2", a: 'ant', b: 'bear'},
+        #     {fp: "3", a: 'ant', b: 'bear'},
+        #     {fp: "4", a: 'ant', b: 'bear'},
+        #   ]
+        #   result = Kiba::StreamingRunner.transform_stream(input, xform)
+        #     .map{ |row| row }
+        #   expected = [
+        #     {fp: "1", a: 'apps', b: nil, corr: "y"},
+        #     {fp: "2", a: 'apples', b: 'bee', corr: "y"},
+        #     {fp: "3", a: 'ant', b: 'bear', corr: "n"},
+        #     {fp: "4", a: 'ant', b: 'bear', corr: "n"},
+        #   ]
+        #   expect(result).to eq(expected)
+        #
         # @example With fieldmap and tag_affected_in
         #   # Used in pipeline as:
         #   # transform Fingerprint::MergeCorrected,


### PR DESCRIPTION
The `Fingerprint::MergeCorrected` transform turned out not to be the issue, so no changes are made to the code. 

The test is retained to clarify that the `fieldmap` and `tag_affected_in` parameters are independent.