### PR TITLE
feat: Add final_lookup_sources to IterativeCleanup

### DIFF
--- a/lib/kiba/extend/mixins/iterative_cleanup.rb
+++ b/lib/kiba/extend/mixins/iterative_cleanup.rb
@@ -72,6 +72,7 @@ module Kiba
       # - {collation_delim}
       # - {clean_fingerprint_flag_ignore_fields}
       # - {final_lookup_on_field}
+      # - {final_lookup_sources}
       #
       # ## What extending this module does
       #
@@ -281,6 +282,10 @@ module Kiba
         def final_lookup_on_field
           orig_values_identifier
         end
+
+        # @return [Array<Symbol>] job keys of registered jobs to be used as
+        #   lookup tables in the `cleanup_base_name__final` job
+        def final_lookup_sources = []
 
         # DO NOT OVERRIDE REMAINING METHODS
 

--- a/lib/kiba/extend/mixins/iterative_cleanup/jobs/final.rb
+++ b/lib/kiba/extend/mixins/iterative_cleanup/jobs/final.rb
@@ -12,7 +12,8 @@ module Kiba
               Kiba::Extend::Jobs::Job.new(
                 files: {
                   source: mod.base_job_cleaned_job_key,
-                  destination: mod.final_job_key
+                  destination: mod.final_job_key,
+                  lookup: mod.final_lookup_sources
                 },
                 transformer: get_xforms(mod)
               )


### PR DESCRIPTION
Supports using transforms dependent on having a lookup table in `cleanup_base_name__final` job transformation logic