### PR TITLE
Convert mermaid to PDF instead of PNG

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ spec/fixtures/*.mrk
 .rubocop-https*
 *.mmd
 *.png
+*.pdf

--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -69,8 +69,8 @@ https://github.com/lyrasis/kiba-extend/pull/260[PR#260]
 https://github.com/lyrasis/kiba-extend/pull/260[PR#260]
 * Handling of `omit_from_all_fields` param to https://lyrasis.github.io/kiba-extend/Kiba/Extend/Transforms/Allable.html[`Allable` transform mixin] and all transforms that use it
 https://github.com/lyrasis/kiba-extend/pull/260[PR#260]
-* `thor job graph` command, which will generate and open a .png dependency graph for the specified job key
-https://github.com/lyrasis/kiba-extend/pull/264[PR#264]
+* `thor job graph` command, which will generate and open a .pdf dependency graph for the specified job key
+https://github.com/lyrasis/kiba-extend/pull/265[PR#265]
 
 === Bugfixes
 

--- a/lib/tasks/job.thor
+++ b/lib/tasks/job.thor
@@ -29,10 +29,10 @@ class Job < Thor
     mmd_path = File.join(mmd_dir, "#{job}.mmd")
     File.open(mmd_path, "w") { |f| f << mermaid }
 
-    png_path = File.join(mmd_dir, "#{job}.png")
-    `mmd-cli -i #{mmd_path} -o #{png_path}`
+    pdf_path = File.join(mmd_dir, "#{job}.pdf")
+    `mmd-cli -i #{mmd_path} -o #{pdf_path} -f`
 
-    `open #{png_path}`
+    `open #{pdf_path}`
     exit(0)
   end
 


### PR DESCRIPTION
.png quality gets cruddy as graph gets bigger. Mac does not come with a native .svg viewer. The other easy alternative is .pdf, so here we are.